### PR TITLE
implemented rental execution and termination logic to STX-Blockgrounds with read-only status helpers

### DIFF
--- a/contracts/STX-Blockgrounds.clar
+++ b/contracts/STX-Blockgrounds.clar
@@ -114,3 +114,99 @@
                         })
                     (ok true))))))
 
+
+(define-public (rent-virtual-land (token-id uint) (rental-period uint))
+    (let (
+        (token-owner (unwrap! (get-owner token-id) err-token-not-found))
+        (rental (unwrap! (map-get? rental-details { token-id: token-id }) err-token-not-found))
+        (price (unwrap! (get rental-price rental) err-token-not-found))
+        (current-block-height stacks-block-height)  ;; block-height is already a uint
+        (rental-end-height (+ stacks-block-height rental-period))
+    )
+        (begin
+            ;; Check if land is not already rented
+            (asserts! (is-none (get tenant rental)) err-already-rented)
+
+            ;; Validate rental period
+            (asserts! (> rental-period u0) err-invalid-rental-period)
+
+            ;; Optional: Add maximum rental period check
+            (asserts! (<= rental-period MAX-RENTAL-PERIOD) err-exceeds-max-rental)
+
+            ;; Check if price is valid
+            (asserts! (> price u0) err-invalid-price)
+
+            ;; Transfer rental payment in STX
+            (try! (stx-transfer? price tx-sender token-owner))
+
+            ;; Update rental details
+            (ok (map-set rental-details
+                { token-id: token-id }
+                {
+                    tenant: (some tx-sender),
+                    rental-start: (some current-block-height),
+                    rental-end: (some rental-end-height),
+                    rental-price: (some price)
+                })))))
+
+
+(define-constant ERR-NOT-AUTHORIZED (err u406))
+(define-constant ERR-RENTAL-NOT-EXPIRED (err u407))
+
+(define-public (end-virtual-land-rental (token-id uint))
+    (let (
+        (rental (unwrap! (map-get? rental-details { token-id: token-id }) err-token-not-found))
+        (current-height stacks-block-height)  ;; block-height is already a uint
+        (rental-end-height (unwrap! (get rental-end rental) err-not-rented))
+        (current-tenant (unwrap! (get tenant rental) err-not-rented))
+    )
+        (begin
+            ;; Check if land is currently rented
+            (asserts! (is-some (get tenant rental)) err-not-rented)
+
+            ;; Check if rental period has ended
+            (asserts! (>= current-height rental-end-height) ERR-RENTAL-NOT-EXPIRED)
+
+            ;; Optional: Check if caller is authorized (either owner or tenant)
+            (asserts! (or 
+                (is-eq tx-sender current-tenant)
+                (is-eq tx-sender (unwrap! (get-owner token-id) err-token-not-found))
+            ) ERR-NOT-AUTHORIZED)
+
+            ;; Reset rental details
+            (ok (map-set rental-details
+                { token-id: token-id }
+                {
+                    tenant: none,
+                    rental-start: none,
+                    rental-end: none,
+                    rental-price: none
+                })))))
+
+;; Read-only helper functions
+(define-read-only (is-land-rented (token-id uint))
+    (match (map-get? rental-details { token-id: token-id })
+        rental (is-some (get tenant rental))
+        false))
+
+(define-read-only (get-land-tenant (token-id uint))
+    (match (map-get? rental-details { token-id: token-id })
+        rental (ok (get tenant rental))
+        (err err-token-not-found)))
+
+(define-read-only (get-rental-expiry (token-id uint))
+    (match (map-get? rental-details { token-id: token-id })
+        rental (ok (get rental-end rental))
+        (err err-token-not-found)))
+
+;; Market statistics
+(define-read-only (get-total-lands)
+    (ok (var-get last-token-id)))
+
+(define-read-only (get-active-rentals)
+    (ok (fold check-if-rented (list u1 u2 u3 u4 u5) u0)))
+
+(define-private (check-if-rented (token-id uint) (sum uint))
+    (if (is-land-rented token-id)
+        (+ sum u1)
+        sum))


### PR DESCRIPTION

###  Pull Request Description

---

### **Title**: Add Full Rental Lifecycle to STX-Blockgrounds Smart Contract

---

### **Overview**

This PR extends the `STX-Blockgrounds` smart contract by implementing the **rental lifecycle functionality**, allowing users to initiate rentals, track ongoing leases, and terminate rentals once expired. These updates provide critical infrastructure for a decentralized virtual land leasing marketplace on the Stacks blockchain.

---

### **New Functionality**

#### 🔑 `rent-virtual-land (token-id, rental-period)`

* Allows a user (tenant) to rent a listed virtual land NFT by:

  * Paying the STX rental fee directly to the landowner.
  * Defining a rental duration in block height.
  * Ensuring the land is not already rented and meets pricing and duration rules.
* Enforces constraints like:

  * Rental period must be > `u0` and ≤ `MAX-RENTAL-PERIOD` (default: 52,560 blocks).
  * Land must have a valid price set and not currently rented.

#### 🛑 `end-virtual-land-rental (token-id)`

* Terminates an active rental **after it expires**.
* Callable by either the tenant or the landowner.
* Validates:

  * Land is currently rented.
  * Current block height is greater than or equal to the rental's `rental-end`.
* Resets the rental details, making the land rentable again.

---

### **Helper Functions (Read-only)**

* `is-land-rented`: Boolean check for rental activity.
* `get-land-tenant`: Returns the current tenant (if any).
* `get-rental-expiry`: Returns the block height at which the rental ends.

---

### **Market Metrics**

* `get-total-lands`: Returns total NFTs minted.
* `get-active-rentals`: Returns a count of rented tokens within a sample token ID range (currently hardcoded for IDs 1–5).
* Private function `check-if-rented`: Used by `get-active-rentals` to tally active leases.

---

### **Error Handling**

New constants:

* `ERR-NOT-AUTHORIZED`: Returned if unauthorized caller tries to end a rental.
* `ERR-RENTAL-NOT-EXPIRED`: Returned if a rental is ended before its expiry block.

All rental logic uses `asserts!` and `unwrap!` for strict on-chain state safety.

---

### ✅ Summary

These enhancements bring the contract closer to a complete MVP for decentralized land rentals. Users can now:

* Rent land on-chain using STX.
* View real-time rental status and expiry data.
* Terminate rentals once they've matured.

---

### 🔜 Next Improvements

* [ ] Make `get-active-rentals` fully dynamic using all minted token IDs.
* [ ] Add events (`print`, `emit-event`) for off-chain indexing (requires Clarity 2.1).
* [ ] Extend to support multi-token sets or modular land zones.

---

